### PR TITLE
Switch to using ChaCha20Poly1305Reusable for encryption

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+#language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -245,7 +245,7 @@ class Accessory:
             )
         else:
             print(
-                "To use the QR Code feature, use 'pip install " "HAP-python[QRCode]'",
+                "To use the QR Code feature, use 'pip install HAP-python[QRCode]'",
                 flush=True,
             )
             print(

--- a/pyhap/camera.py
+++ b/pyhap/camera.py
@@ -842,7 +842,7 @@ class Camera(Accessory):
 
         return True
 
-    async def stop_stream(self, session_info):  # pylint: disable=no-self-use
+    async def stop_stream(self, session_info):
         """Stop the stream for the given ``session_id``.
 
         This method can be implemented if custom stop stream commands are needed. The
@@ -886,7 +886,7 @@ class Camera(Accessory):
         """
         await self.start_stream(session_info, stream_config)
 
-    def get_snapshot(self, image_size):  # pylint: disable=unused-argument, no-self-use
+    def get_snapshot(self, image_size):  # pylint: disable=unused-argument
         """Return a jpeg of a snapshot from the camera.
 
         Overwrite to implement getting snapshots from your camera.

--- a/pyhap/hap_crypto.py
+++ b/pyhap/hap_crypto.py
@@ -2,9 +2,9 @@
 import logging
 import struct
 
+from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable as ChaCha20Poly1305
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
-from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable as ChaCha20Poly1305
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 logger = logging.getLogger(__name__)

--- a/pyhap/hap_crypto.py
+++ b/pyhap/hap_crypto.py
@@ -4,7 +4,7 @@ import struct
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable as ChaCha20Poly1305
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 logger = logging.getLogger(__name__)

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -12,7 +12,7 @@ import uuid
 from cryptography.exceptions import InvalidSignature, InvalidTag
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, x25519
-from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable as ChaCha20Poly1305
 
 from pyhap import tlv
 from pyhap.const import (

--- a/pyhap/hap_protocol.py
+++ b/pyhap/hap_protocol.py
@@ -18,7 +18,7 @@ from .hap_handler import HAPResponse, HAPServerHandler
 
 logger = logging.getLogger(__name__)
 
-HIGH_WRITE_BUFFER_SIZE = 2 ** 19
+HIGH_WRITE_BUFFER_SIZE = 2**19
 # We timeout idle connections after 90 hours as we must
 # clean up unused sockets periodically. 90 hours was choosen
 # as its the longest time we expect a user to be away from

--- a/pylintrc
+++ b/pylintrc
@@ -10,6 +10,5 @@ disable=
   too-many-public-methods,
   too-many-return-statements,
   too-many-statements,
-  bad-continuation,
   unused-argument,
   consider-using-with

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.md", "r", encoding="utf-8") as f:
     README = f.read()
 
 
-REQUIRES = ["cryptography", "zeroconf>=0.36.2", "h11"]
+REQUIRES = ["cryptography", "chacha20poly1305-reuseable", "zeroconf>=0.36.2", "h11"]
 
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,5 +52,5 @@ class MockDriver:
     def publish(self, data, client_addr=None, immediate=False):
         pass
 
-    def add_job(self, target, *args):  # pylint: disable=no-self-use
+    def add_job(self, target, *args):
         asyncio.new_event_loop().run_until_complete(target(*args))

--- a/tests/test_characteristic.py
+++ b/tests/test_characteristic.py
@@ -45,7 +45,7 @@ def test_repr():
     char = get_char(PROPERTIES.copy())
     del char.properties["Permissions"]
     assert (
-        char.__repr__() == "<characteristic display_name=Test Char value=0 "
+        repr(char) == "<characteristic display_name=Test Char value=0 "
         "properties={'Format': 'int'}>"
     )
 

--- a/tests/test_hap_protocol.py
+++ b/tests/test_hap_protocol.py
@@ -28,7 +28,7 @@ class MockHAPCrypto:
         self._crypt_in_buffer = bytearray()  # Encrypted buffer
         return decrypted
 
-    def encrypt(self, data):  # pylint: disable=no-self-use
+    def encrypt(self, data):
         """Mock as plaintext."""
         return data
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -30,9 +30,7 @@ def test_repr():
     """Test service representation."""
     service = Service(uuid1(), "TestService")
     service.characteristics = [get_chars()[0]]
-    assert (
-        service.__repr__() == "<service display_name=TestService chars={'Char 1': 0}>"
-    )
+    assert repr(service) == "<service display_name=TestService chars={'Char 1': 0}>"
 
 
 def test_add_characteristic():


### PR DESCRIPTION
The ChaCha20Poly1305 that comes with cryptography recreates the
ctx every time encrypt is called.  Since we call encrypt in
 a loop, we can avoid this overhead by using ChaCha20Poly1305Reusable
instead as we are doing everything in the same thread and not concerned
about thread safety